### PR TITLE
v0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spider-web-search"
 authors = ["Maxim Petrenko <meinbaumm@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 description = "A tool for web search on your favorite sites."

--- a/README.md
+++ b/README.md
@@ -29,10 +29,13 @@ urban           https://www.urbandictionary.com/define.php?term=
 And then you can use spider.
 
 ```bash
+A tool for web search on your favorite sites.
+
 Usage: spider-web-search <COMMAND>
 
 Commands:
   web   Search on the web
+  list  List web sites in the spider file
   help  Print this message or the help of the given subcommand(s)
 
 Options:
@@ -64,6 +67,12 @@ If you want to open main page of website instead of long url for search, just do
 
 ```bash
 spider-web-search web urban
+```
+
+Show your web urls provided in `web-search-urls.spider` file
+
+```bash
+spider-web-search list
 ```
 
 ## How To

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,10 +85,14 @@ fn open_url(url: &str) {
     }
 }
 
-pub fn web_search(web_site_name: &str, search_term: &Option<String>) {
-    let web_search_urls = WebSearchURLs::new()
+fn read_spider_file() -> WebSearchURLs {
+    WebSearchURLs::new()
         .read_urls_file(&get_spider_file(SPIDER_ENV_VARIABLE))
-        .split_and_flesh_out();
+        .split_and_flesh_out()
+}
+
+pub fn web_search(web_site_name: &str, search_term: &Option<String>) {
+    let web_search_urls = read_spider_file();
 
     let url = {
         let url = web_search_urls.get(&web_site_name);
@@ -106,4 +110,19 @@ pub fn web_search(web_site_name: &str, search_term: &Option<String>) {
         Some(search_term) => open_url(&url.format(&search_term)),
         None => open_url(&url.main_page()),
     }
+}
+
+pub fn list_web_search_urls() {
+    let web_search_urls = read_spider_file();
+
+    let max_len = web_search_urls
+        .urls
+        .iter()
+        .map(|(name, _)| name.len())
+        .max()
+        .unwrap();
+
+    web_search_urls.urls.iter().for_each(|(name, url)| {
+        println!("{:width$} {}", name, url.main_page(), width = max_len + 1)
+    });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,8 @@ enum Commands {
         #[arg(value_parser = clap::builder::NonEmptyStringValueParser::new())]
         search_term: Option<String>,
     },
+    /// List the web sites in the spider file
+    List {},
 }
 
 fn main() {
@@ -31,5 +33,7 @@ fn main() {
             web_site_name,
             search_term,
         } => spider_web_search::web_search(&web_site_name, &search_term),
+
+        Commands::List {} => spider_web_search::list_web_search_urls(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ enum Commands {
         #[arg(value_parser = clap::builder::NonEmptyStringValueParser::new())]
         search_term: Option<String>,
     },
-    /// List the web sites in the spider file
+    /// List web sites in the spider file
     List {},
 }
 


### PR DESCRIPTION
- Add `list` command to show all web search urls in `web-search-urls.spider` file.